### PR TITLE
Add 'default' extension for portals

### DIFF
--- a/src/ausweiskopie/ui/__init__.py
+++ b/src/ausweiskopie/ui/__init__.py
@@ -2,6 +2,7 @@
 UI of the Ausweiskopie app.
 """
 import datetime
+import os
 import tkinter as tk
 import traceback
 from collections import OrderedDict
@@ -173,15 +174,36 @@ class MainFrame(ttk.Frame):
             new.putdata(page.getdata())
             pages.append(page)
 
-        if outfile.endswith(".pdf"):
-            pages[0].save(
-                outfile,
-                save_all=True,
-                append_images=pages[1:],
-                title="",
-                creationDate=1,
-                modDate=1,
-            )
+        try:
+            if outfile.lower().endswith(".pdf"):
+                pages[0].save(
+                    outfile,
+                    save_all=True,
+                    append_images=pages[1:],
+                    title="",
+                    creationDate=1,
+                    modDate=1,
+                )
+            else:
+                height = sum(page.height for page in pages)
+                width = max(page.width for page in pages)
+
+                out = Image.new("RGB", (width, height), color="white")
+                heightidx = 0
+                for page in pages:
+                    out.paste(page, (0, heightidx))
+                    heightidx += page.size[1]
+
+                out.save(outfile)
+        except IOError as e:
+            messagebox.showerror("Error writing file",
+                                 "File cannot be opened: %s" % e)
+        except ValueError as e:
+            messagebox.showerror("Unknown file extension",
+                                 str(e))
+        except:
+            messagebox.showerror("Unexpected error", traceback.format_exc())
+
 
     def finish(self):
         ...

--- a/src/ausweiskopie/ui/dialogs.py
+++ b/src/ausweiskopie/ui/dialogs.py
@@ -12,6 +12,7 @@ from tkinter.filedialog import askopenfile, askopenfilename, asksaveasfilename
 from typing import Union, Collection, Tuple, Optional, List, Sequence, Any
 from concurrent.futures import Future
 from urllib.parse import unquote, urlparse, urlencode, quote
+from zoneinfo import reset_tzpath
 
 BUS_NAME_BASE = "org.freedesktop.portal"
 BUS_OBJECT_PATH = "/org/freedesktop/portal/desktop"
@@ -166,7 +167,7 @@ def savefileasname(
         title: Optional[str] = None,
         parent: Optional[tkinter.Tk] = None,
         session_bus: Any = None
-) -> Optional[io.FileIO]:
+) -> Optional[str]:
     """Asks the user to open a file with a dialog."""
     try:
         return savefileasname_desktopportals(
@@ -188,6 +189,20 @@ def savefileasname(
             title=title,
         )
 
+
+def _get_current_extension(result) -> Optional[str]:
+    if not result.get('current_filter'):
+        return None
+    if not result['current_filter'][1]:
+        return None
+    if not result['current_filter'][1][0]:
+        return None
+    if not result['current_filter'][1][0][1]:
+        return None
+
+    ext = os.path.splitext(result['current_filter'][1][0][1])[1]
+    if ext:
+        return ext
 
 def savefileasname_desktopportals(
         defaultextension: Optional[str] = None,
@@ -224,7 +239,13 @@ def savefileasname_desktopportals(
     if status != 0:
         return None
     uri: str = result["uris"][0]
-    return unquote(urlparse(uri).path)
+    fn = unquote(urlparse(uri).path)
+    if not os.path.splitext(fn)[1]:
+        if _get_current_extension(result):
+            fn += _get_current_extension(result)
+        if not os.path.splitext(fn)[1] and defaultextension is not None:
+            fn += defaultextension
+    return fn
 
 
 def savefileasname_tk(


### PR DESCRIPTION
Add e.g. '.pdf' if the user enters no file extension.  This PR also implements saving as JPG and PNG. This was already selectable in the UI, but was not implemented.