### PR TITLE
temporary id: extend eye color box

### DIFF
--- a/src/ausweiskopie/redact/fields.py
+++ b/src/ausweiskopie/redact/fields.py
@@ -195,7 +195,7 @@ FIELDS_VORLAEUFIG_FRONT: FieldDefinition = {
         Location((0.5125, 0.4575), (0.6340, 0.5125)),
     ),
     Field.COLOUR_OF_EYES: (
-        Location((0.6340, 0.4575), (0.8306, 0.5125)),
+        Location((0.6340, 0.4575), (0.9664, 0.5125)),
     ),
     Field.ADDRESS: (
         Location((0.2733, 0.5289), (0.9664, 0.5733)),


### PR DESCRIPTION
In case the stated eye color is quite long (e.g. when the colors differ between the two, or within one, eye), there is still something left visible.

To illustrate this, look at the following temporary German ID: 

Starting of with this scan,
![unredacted](https://github.com/user-attachments/assets/ac97a2cb-9a04-4cd9-b2d8-f8afe989efde)

you currently end up with this when redacting the eye color:
![semi-redacted](https://github.com/user-attachments/assets/97a7f1fe-5f4b-4ad8-a399-befa31893f14)

As you can see, the "brown" of the "Blaubraun" is still visible. This PR extends the eye-color box to the right, as far as the given name box extends on the x axis.

This does not appear to be a problem on the regular German ID, on there the value does not (tho there is only little additional room to spare) extend the `Augenfarbe / Color of eyes / Coleur des yeux` field title / description. The passport doesn't contain the eye color on the plastic page where the other fields are located.