### PR TITLE
Add package managers and fix typo

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -57,7 +57,7 @@ jobs:
           path: dist/
 
   build-macos-intel:
-    name: Build binary for MacOS (Intel)
+    name: Build binary for macOS (Intel)
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
           path: dist/
 
   build-macos-arm64:
-    name: Build binary for MacOS (ARM64)
+    name: Build binary for macOS (ARM64)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -195,12 +195,12 @@ jobs:
       with:
         name: pyinstaller-binaries
         path: dist/
-    - name: Download MacOS intel executables
+    - name: Download macOS intel executables
       uses: actions/download-artifact@v4
       with:
         name: pyinstaller-binaries-macos-intel
         path: dist/
-    - name: Download MacOS ARM64 executables
+    - name: Download macOS ARM64 executables
       uses: actions/download-artifact@v4
       with:
         name: pyinstaller-binaries-macos-arm64

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Alternatively, visit the store page for further details:
 
 [![Get it on Flathub](https://flathub.org/api/badge?locale=en)](https://flathub.org/apps/in.varb.Ausweiskopie)
 
-### Binaries on GitHub Releases for Windows and MacOS
+### Binaries on GitHub Releases for Windows and macOS
 
-You can download the latest Windows and MacOS binaries from [the releases page](https://github.com/Varbin/Ausweiskopie/releases/latest/).
+You can download the latest Windows and macOS binaries from [the releases page](https://github.com/Varbin/Ausweiskopie/releases/latest/).
 The binaries work without installation.
 
 ### From a package manager
@@ -105,7 +105,7 @@ Für weitere Details besuche die Marktplatzseite:
 
 [![Jetzt auf Flathub](https://flathub.org/api/badge?locale=de)](https://flathub.org/apps/in.varb.Ausweiskopie)
 
-### Windows- und MacOS Dateien unter den GitHub Releases
+### Windows- und macOS Dateien unter den GitHub Releases
 
 Die neusten Pakete findest du unter [Releases](https://github.com/Varbin/Ausweiskopie/releases/latest/).
 Du kannst die Anwendung direkt ohne Installation ausführen.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Alternatively, visit the store page for further details:
 You can download the latest Windows and MacOS binaries from [the releases page](https://github.com/Varbin/Ausweiskopie/releases/latest/).
 The binaries work without installation.
 
+### From a package manager
+
+These are packages contributed by the community.
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/ausweiskopie.svg)](https://repology.org/project/ausweiskopie/versions)
+
 ### From PyPI
 
 [![PyPI](https://img.shields.io/badge/ausweiskopie-blue?style=for-the-badge&logo=pypi&label=PyPI&labelColor=white)](https://pypi.org/project/ausweiskopie)
@@ -103,6 +109,12 @@ Für weitere Details besuche die Marktplatzseite:
 
 Die neusten Pakete findest du unter [Releases](https://github.com/Varbin/Ausweiskopie/releases/latest/).
 Du kannst die Anwendung direkt ohne Installation ausführen.
+
+### Mittels Paketmanager
+
+Dies sind Pakete bereitgestellt von der Community.
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/ausweiskopie.svg)](https://repology.org/project/ausweiskopie/versions)
 
 ### Von PyPI
 


### PR DESCRIPTION
- Adds a repology badge for all packaged binaries of Ausweiskopie
- Fixes MacOS typos in README.md