### PR TITLE
Add Pydantic model for new scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Your Python installation must have the `tkinter`.
 
 Optional features:
  - **Modern theme**: This application will make use of _ttkbootstrap_ if available. Just run `pip install ausweiskopie[modern]`
- - **XDG Desktop Portals** (native file open/save-as dialogs on Linux): If your desktop manager provides XDG portals, just install `pip install ausweiskopie[portals]`.
+ - **XDG Desktop Portals** (native file open/save-as dialogs on Linux/BSD): If your desktop manager provides XDG portals, just install `pip install ausweiskopie[portals]`.
  - **Drag-and-Drop**: If your Tk/Tcl environment has the `tkdnd` extension, Drag-and-drop support is automatically enabled.
 
 # Meine Ausweiskopie
@@ -129,5 +129,5 @@ Deine Python-Installation muss `tkinter` installiert haben.
 
 Optionale-Features:
  - **Modernes Look-and-Feel**: Mittels *ttkbootstrap* kann der Anwendung ein modernes Aussehen übergestülpt werden, zur Installation `pip install ausweiskopie[modern]` ausführen.
- - **XDK Desktop Portals** (Natives Datei-Öffenen-/Speichern-Unter unter Linux): Die meisten Desktop-Umgebungen stellen diese mittlerweile bereit. Zur Installation `pip install ausweiskopie[portals]` durchführen.
+ - **XDG Desktop Portals** (Natives Datei-Öffenen-/Speichern-Unter unter Linux/BSDs): Die meisten Desktop-Umgebungen stellen diese mittlerweile bereit. Zur Installation `pip install ausweiskopie[portals]` durchführen.
  - **Drag-and-Drop**: Wenn `tkdnd` in deiner Tk/Tcl-Installation vorhanden ist, funktioniert Drag-und-Drop von Bildern.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,15 @@ authors = [
 ]
 dependencies = [
     "pillow >= 8.0.0",
-    "importlib-resources"
+    "importlib-resources",
+    "pydantic",
+    "tomli; python_version<='3.11'"
 ]
 
 [project.optional-dependencies]
 portals = [
-    "dbus-python; sys_platform=='linux'", "pygobject; sys_platform=='linux'"
+    "dbus-python; platform_system=='Linux' or platform_system=='FreeBSD' or platform_system=='OpenBSD'",
+    "pygobject; platform_system=='Linux' or platform_system=='FreeBSD' or platform_system=='OpenBSD'"
 ]
 modern = [
     "ttkbootstrap >= 1.0"

--- a/src/ausweiskopie/redact/__init__.py
+++ b/src/ausweiskopie/redact/__init__.py
@@ -2,7 +2,7 @@
 Redact fields of identity documents.
 """
 
-from typing import Collection
+from typing import Collection, List
 
 from .definitions import *
 from .fields import *
@@ -24,10 +24,12 @@ __all__ = [
     "FIELDS_PASSPORT"
 ]
 
+from ..resources import Rectangle
+
 
 def redact(image: Image.Image,
-           fields_to_redact: Collection[Field],
-           field_definitions: FieldDefinition,
+           fields_to_redact: Collection[str],
+           field_definitions: Mapping[str, List[Rectangle]],
            show_instead_of_redact=False,
            color="black",
            ) -> Image.Image:
@@ -46,8 +48,8 @@ def redact(image: Image.Image,
     fill = None if show_instead_of_redact else color
 
     for field in fields_to_redact:
-        for definition in field_definitions.get(field, ()):
-            coordinates = definition.rectangle_coordinates(image)
+        for definition in field_definitions.get(field, []):
+            coordinates = Location(definition["tl"], definition["br"]).rectangle_coordinates(image)
             draw.rectangle(coordinates, fill, color)
 
     return image

--- a/src/ausweiskopie/redact/document.py
+++ b/src/ausweiskopie/redact/document.py
@@ -1,0 +1,119 @@
+import dataclasses
+import datetime
+import enum
+import uuid
+from typing import Optional, Tuple, Dict, List
+from annotated_types import Gt
+
+from pydantic import BaseModel
+from typing_extensions import NotRequired, Annotated, TypedDict
+
+
+class Side(str, enum.Enum):
+    """Sides of id documents."""
+    FRONT = "front"
+    BACK = "back"
+
+
+class Rectangle(TypedDict):
+    """Rectangle on a side."""
+    tl: Tuple[Annotated[float, Gt(0)], Annotated[float, Gt(0)]]
+    br: Tuple[Annotated[float, Gt(0)], Annotated[float, Gt(0)]]
+
+
+Layout = TypedDict("Layout", {
+    Side.FRONT: Dict[str, List[Rectangle]],
+    Side.BACK: NotRequired[Dict[str, List[Rectangle]]],
+})
+
+
+class MRZ(str, enum.Enum):
+    """Possible ICAO MRZ variants.
+
+    Other forms of MRZ (QR codes, PDF417, bar code) will get their own field.
+    """
+    TD1 = "TD-1"
+    TD2 = "TD-2"
+    TD3 = "TD-3"
+
+    def coordinates(self) -> Dict[Side, Rectangle]:
+        """Return the positions of the MRZ."""
+        if self == MRZ.TD1:
+            return {}
+        elif self == MRZ.TD2:
+            return {}
+        elif self == MRZ.TD3:
+            return {}
+
+
+class Type(str, enum.Enum):
+    """Possible document types"""
+    # ID cards or papers
+    ID = "id"
+
+    # Passport (usually the copy of the bio card)
+    PASSPORT = "passport"
+
+    # Driving permits or similar licenses, they might serve as an id document
+    DRIVING_PERMIT = "driving-permit"
+
+    # Special passport-like travel documents for members of some organizations
+    # (e.g., UN, Red-Cross, EU)
+    LAISSEZ_PASSER = "laissez-passer"
+
+    # Documents allowing to live in some country
+    RESIDENCY_PERMIT = "residency-permit"
+
+    # Some countries issue special seafarer documents (similar to passports) to
+    # ease traveling from / to ships
+    SEAFARER = "seafarer"
+
+    # Other documents
+    OTHER = "other"
+
+
+class Subtype(str, enum.Enum):
+    """Possible document subtypes"""
+    # Temporary or emergency documents, issued if the original documents were
+    # lost, or they need to be issued in a short amount of time
+    TEMPORARY = "temporary"
+
+    # Diplomatic passports issued for diplomats
+    DIPLOMATIC = "diplomatic"
+
+    # Service passports, issued for members of the state
+    SERVICE = "service"
+
+    # Other non-standard type of the document
+    OTHER = "other"
+
+
+@dataclasses.dataclass
+class Metadata:
+    """Document metadata"""
+    issuer: str
+    type: Type
+    subtype: str
+    issuedSince: datetime.date
+    issuedUntil: Optional[datetime.date] = None
+    revision: Optional[str] = None
+    mrz: Optional[MRZ] = None
+    mrzId: Optional[str] = None
+    dimensions: Optional[str] = None
+    dimensionsCustom: Optional[Tuple[float, float]] = None
+
+    @property
+    def dimensionSize(self) -> Tuple[float, float]:
+        pass
+
+@dataclasses.dataclass
+class Document(BaseModel):
+    id: uuid.UUID
+    meta: Metadata
+    layout: Layout
+    i18n: Dict[str, Dict[str, str]]
+
+    def merged_side(self, side: Side) -> List[Rectangle]:
+        pass
+
+

--- a/src/ausweiskopie/resources/__init__.py
+++ b/src/ausweiskopie/resources/__init__.py
@@ -2,16 +2,24 @@
 Resources for the package.
 """
 import csv
+import json
 import locale
-import platform
 import sys
-import typing
-from typing import Optional
+import uuid
+from pathlib import Path
+from typing import NewType, Optional, Union, Literal, Iterable, Callable, \
+    BinaryIO, cast
 
+import tomli
 from importlib_resources import files
 
+from .document import Side, Rectangle, Layout, MRZ, Type, Subtype, Dimension, \
+    Metadata, Document
 
-__all__ = ["EXAMPLE_NPA_2010", "EXAMPLE_NPA_2019", "EXAMPLE_NPA_2021", "EXAMPLE_NPA_BACK", "EXAMPLE_CH_NIDK_2023", "EXAMPLE_CH_NIDK_2023_BACK", "FONT_NOTOSANS_REGULAR", "TRANSLATIONS", "ICON", "get_resource", "set_locale", "get_string", "_"]
+__all__ = ["EXAMPLE_NPA_2010", "EXAMPLE_NPA_2019", "EXAMPLE_NPA_2021", "EXAMPLE_NPA_BACK", "EXAMPLE_CH_NIDK_2023", "EXAMPLE_CH_NIDK_2023_BACK", "FONT_NOTOSANS_REGULAR", "TRANSLATIONS", "ICON", "get_resource", "set_locale", "get_string", "_",
+           "Side", "Rectangle", "Layout", "MRZ", "Type", "Subtype", "Dimension", "Metadata", "Document",
+           "load_documents", "document_title"
+]
 
 
 EXAMPLE_NPA_2010 = "npa_2010.jpg"
@@ -31,8 +39,20 @@ ICON_COLORED = "icon_colored.png"
 _locale: Optional[str] = None
 _strings: dict[str, dict[str, str]] = {}
 
+# Ensure only "valid" directories can be passed to list_resources.
+ResourceDirectory = NewType("ResourceDirectory", str)
+DOCUMENTS = ResourceDirectory("documents")
+SCHEMAS = ResourceDirectory("schemas")
 
-def get_resource(fn, mode="rb", *args, **kwargs):
+
+def list_resources(directory: ResourceDirectory) -> list[Path]:
+    """Returns an array of filenames in a resources directory.
+    Each file name can be passed to get_resource()."""
+    base = files(__name__)
+    return list(map(lambda p: p.relative_to(base), base.joinpath(directory).iterdir()))
+
+
+def get_resource(fn, mode: Literal["r", "rb"] = "rb", *args, **kwargs):
     """Get a resource file."""
     return files(__name__).joinpath(fn).open(mode, *args, **kwargs)
 
@@ -50,6 +70,14 @@ def set_locale(new_locale: Optional[str] = None):
         else:
             new_locale = new_locale[:2].lower()
     _locale = new_locale
+
+
+def get_locale() -> str:
+    """Returns the locale."""
+    if _locale is None:
+        set_locale()
+    return _locale
+
 
 
 def get_string(key: str) -> str:
@@ -82,3 +110,101 @@ def get_string(key: str) -> str:
 
 
 _ = get_string
+
+
+def load_document(fd: BinaryIO, toml: bool = False) -> Document:
+    """Parses a document from a binary file descriptor."""
+    if toml:
+        obj = tomli.load(fd)
+    else:
+        obj = json.load(fd)
+
+    return Document.model_validate(obj)
+
+
+def load_documents(
+        internal_documents: bool = False,
+        additional_paths: Iterable[Union[str, Path]] = (),
+        progress: Optional[Callable[[int, int], None]] = None,
+        conflict: Optional[Callable[[Document, Document], int]] = None,
+        error: Optional[Callable[[str, Exception], bool]] = None,
+) -> dict[uuid.UUID, Document]:
+    """Load document definitions (JSON or TOML)
+    from the given paths and by default all internal ones.
+    Paths will not be searched recursively.
+
+    You can pass callbacks for interactive usage.
+    The progress function takes the already parsed and maximum values.
+    The conflict function takes two documents,
+    and returns the index for the chosen one.
+    The function may return 2 to keep both.
+    If loading a document throws an exception,
+    the error function together with the filename will be called.
+    The function should return true to supress the error.
+    """
+    documents = {}
+    loaded = 0
+
+    def report_progress():
+        """Call the progress function if defined."""
+        if progress is not None:
+            progress(loaded, len(internal_docs) + len(external_docs))
+
+    internal_docs = []
+    external_docs = []
+    if internal_documents:
+        internal_docs = list_resources(DOCUMENTS)
+
+    for path in additional_paths:
+        external_docs.extend(Path(path).glob("*.json"))
+        external_docs.extend(Path(path).glob("*.toml"))
+
+    report_progress()
+
+    for doc in internal_docs:
+        loaded += 1
+        with get_resource(doc, 'rb') as res:
+            res = cast(BinaryIO, res)
+            document = load_document(res, doc.suffix == '.toml')
+
+            # No collision detection on internal document definitions
+            documents[document.id] = document
+
+            report_progress()
+
+    for doc in external_docs:
+        loaded += 1
+        try:
+            with open(doc, 'rb') as res:
+                # open with 'rb' always returns a BytesIO,
+                # but PyCharm does not know this.
+                res = cast(BinaryIO, res)
+                document = load_document(res, doc.suffix == '.toml')
+        except (ValueError, IOError) as e:
+            if error is not None:
+                if error(str(doc), e):
+                    continue
+                else:
+                    raise e
+            else:
+                raise e
+
+        if document.id in documents.keys() and conflict is not None:
+            ret = conflict(documents[document.id], document)
+            if ret == 0:
+                continue
+            elif ret == 1:
+                pass
+            else:
+                document.id = uuid.uuid4()
+
+        documents[document.id] = document
+        report_progress()
+
+    report_progress()
+    return documents
+
+
+def document_title(document: Document) -> str:
+    title = document.i18n["DOCUMENT_NAME"]
+    return title.get(get_locale(), title['en'])

--- a/src/ausweiskopie/resources/document.py
+++ b/src/ausweiskopie/resources/document.py
@@ -3,10 +3,12 @@ import datetime
 import enum
 import uuid
 from typing import Optional, Tuple, Dict, List
-from annotated_types import Gt
 
+from annotated_types import Gt
 from pydantic import BaseModel
 from typing_extensions import NotRequired, Annotated, TypedDict
+
+from ..redact import Location
 
 
 class Side(str, enum.Enum):
@@ -20,6 +22,8 @@ class Rectangle(TypedDict):
     tl: Tuple[Annotated[float, Gt(0)], Annotated[float, Gt(0)]]
     br: Tuple[Annotated[float, Gt(0)], Annotated[float, Gt(0)]]
 
+    def location(self) -> Location:
+        return Location(self.tl, self.br)
 
 Layout = TypedDict("Layout", {
     Side.FRONT: Dict[str, List[Rectangle]],
@@ -38,12 +42,15 @@ class MRZ(str, enum.Enum):
 
     def coordinates(self) -> Dict[Side, Rectangle]:
         """Return the positions of the MRZ."""
+        # TODO: Implement
         if self == MRZ.TD1:
             return {}
         elif self == MRZ.TD2:
             return {}
         elif self == MRZ.TD3:
             return {}
+        else:
+            raise NotImplementedError(f"MRZ coordinates not implemented for {self}")
 
 
 class Type(str, enum.Enum):
@@ -84,36 +91,76 @@ class Subtype(str, enum.Enum):
     # Service passports, issued for members of the state
     SERVICE = "service"
 
+    # Travel documents issued to stateless persons
+    STATELESS = "stateless"
+
+    # Travel documents issued to non-citizens
+    NONCITIZEN = "noncitizen"
+
+    # Travel documents issued to refugess
+    REFUGEE = "refugee"
+
     # Other non-standard type of the document
     OTHER = "other"
+
+
+class Dimension(str, enum.Enum):
+    """Possible document dimensions (i.e. proportions)"""
+    # Standard "credit card" size; also known as CR-80 or TD1
+    ID1 = "ID-1"
+    # Paper visas, temporary IDs, also the old style Ausweis
+    ID2 = "ID-2"
+    # Passport booklets
+    ID3 = "ID-3"
+    # Some rarer kind
+    CR90 = "CR-90"
+    # Size is defined in a different property.
+    CUSTOM = "custom"
+
+    def size(self) -> Tuple[float, float]:
+        """Returns values of a dimension in millimeters."""
+        if self == Dimension.ID1:
+            return 85.6, 53.98
+        if self == Dimension.ID2:
+            return 105, 74
+        if self == Dimension.ID3:
+            return 125, 88
+        if self == Dimension.CR90:
+            return 92, 60
+
+        raise NotImplementedError("A custom dimension has no size.")
 
 
 @dataclasses.dataclass
 class Metadata:
     """Document metadata"""
-    issuer: str
-    type: Type
-    subtype: str
-    issuedSince: datetime.date
-    issuedUntil: Optional[datetime.date] = None
+    dimensions: Dimension  # How large is this document
+    issuer: str  # Issuing country
+    type: Type  # What type of document is this
+    issuedSince: datetime.date  # Since when is this kind of document circulated?
+
+    subtype: Optional[Subtype] = None
+    issuedUntil: Optional[datetime.date] = None  # None = currently issued
     revision: Optional[str] = None
     mrz: Optional[MRZ] = None
     mrzId: Optional[str] = None
-    dimensions: Optional[str] = None
     dimensionsCustom: Optional[Tuple[float, float]] = None
 
     @property
     def dimensionSize(self) -> Tuple[float, float]:
-        pass
+        """Returns the dimensions of a document in millimetres,
+        independent of if a well known dimension is passed or a custom one."""
+        if self.dimensions != Dimension.CUSTOM:
+            return self.dimensions.size()
+        return self.dimensionsCustom
+
 
 @dataclasses.dataclass
 class Document(BaseModel):
+    """Document describes a single revision of a type of identity document.
+    Every revision must have a different id."""
     id: uuid.UUID
     meta: Metadata
     layout: Layout
     i18n: Dict[str, Dict[str, str]]
-
-    def merged_side(self, side: Side) -> List[Rectangle]:
-        pass
-
 

--- a/src/ausweiskopie/resources/document.py
+++ b/src/ausweiskopie/resources/document.py
@@ -137,7 +137,7 @@ class Metadata:
     dimensions: Dimension  # How large is this document
     issuer: str  # Issuing country
     type: Type  # What type of document is this
-    issuedSince: datetime.date  # Since when is this kind of document circulated?
+    issuedSince: datetime.date  # Since when is this kind of document in circulation?
 
     subtype: Optional[Subtype] = None
     issuedUntil: Optional[datetime.date] = None  # None = currently issued

--- a/src/ausweiskopie/resources/documents/deu_id_temporary_2010-11-01.json
+++ b/src/ausweiskopie/resources/documents/deu_id_temporary_2010-11-01.json
@@ -1,0 +1,355 @@
+{
+  "$schema": "https://schema.varb.in/in.varb.Ausweiskopie/document.json",
+  "id": "becf99c3-a872-4765-adb5-89e5e8eb74c7",
+  "meta": {
+    "dimensions": "ID-2",
+    "issuer": "DEU",
+    "issuedSince": "2010-11-01",
+    "type": "id",
+    "subtype": "temporary",
+    "mrz": "TD-2",
+    "mrzId": "ITD<<"
+  },
+  "layout": {
+    "front": {
+      "DOCUMENT_NUMBER": [
+        {
+          "tl": [
+            0.7583,
+            0.18
+          ],
+          "br": [
+            0.9664,
+            0.25
+          ]
+        },
+        {
+          "tl": [
+            0.04,
+            0.867
+          ],
+          "br": [
+            0.2462,
+            0.93
+          ]
+        }
+      ],
+      "PHOTO": [
+        {
+          "tl": [
+            0.0105,
+            0.05
+          ],
+          "br": [
+            0.2733,
+            0.5525
+          ]
+        }
+      ],
+      "SURNAME": [
+        {
+          "tl": [
+            0.2733,
+            0.18
+          ],
+          "br": [
+            0.753,
+            0.235
+          ]
+        },
+        {
+          "tl": [
+            0.04,
+            0.804
+          ],
+          "br": [
+            0.7795,
+            0.867
+          ]
+        }
+      ],
+      "NAME_AT_BIRTH": [
+        {
+          "tl": [
+            0.2733,
+            0.235
+          ],
+          "br": [
+            0.753,
+            0.295
+          ]
+        }
+      ],
+      "GIVEN_NAME": [
+        {
+          "tl": [
+            0.2733,
+            0.3137
+          ],
+          "br": [
+            0.9664,
+            0.37
+          ]
+        },
+        {
+          "tl": [
+            0.04,
+            0.804
+          ],
+          "br": [
+            0.7795,
+            0.867
+          ]
+        }
+      ],
+      "DATE_OF_BIRTH": [
+        {
+          "tl": [
+            0.2733,
+            0.3861
+          ],
+          "br": [
+            0.4693,
+            0.445
+          ]
+        },
+        {
+          "tl": [
+            0.3074,
+            0.867
+          ],
+          "br": [
+            0.4503,
+            0.93
+          ]
+        }
+      ],
+      "PLACE_OF_BIRTH": [
+        {
+          "tl": [
+            0.4693,
+            0.3861
+          ],
+          "br": [
+            0.9664,
+            0.445
+          ]
+        }
+      ],
+      "NATIONALITY": [
+        {
+          "tl": [
+            0.2773,
+            0.4575
+          ],
+          "br": [
+            0.4816,
+            0.5125
+          ]
+        },
+        {
+          "tl": [
+            0.2462,
+            0.867
+          ],
+          "br": [
+            0.3074,
+            0.93
+          ]
+        }
+      ],
+      "HEIGHT": [
+        {
+          "tl": [
+            0.5125,
+            0.4575
+          ],
+          "br": [
+            0.634,
+            0.5125
+          ]
+        }
+      ],
+      "COLOUR_OF_EYES": [
+        {
+          "tl": [
+            0.634,
+            0.4575
+          ],
+          "br": [
+            0.9664,
+            0.5125
+          ]
+        }
+      ],
+      "ADDRESS": [
+        {
+          "tl": [
+            0.2733,
+            0.5289
+          ],
+          "br": [
+            0.9664,
+            0.5733
+          ]
+        }
+      ],
+      "DATE": [
+        {
+          "tl": [
+            0.2733,
+            0.5956
+          ],
+          "br": [
+            0.6163,
+            0.6428
+          ]
+        }
+      ],
+      "DATE_OF_EXPIRY": [
+        {
+          "tl": [
+            0.6163,
+            0.5959
+          ],
+          "br": [
+            0.9644,
+            0.6428
+          ]
+        },
+        {
+          "tl": [
+            0.4714,
+            0.867
+          ],
+          "br": [
+            0.6136,
+            0.93
+          ]
+        }
+      ],
+      "SIGNATURE": [
+        {
+          "tl": [
+            0.2733,
+            0.666
+          ],
+          "br": [
+            0.9644,
+            0.781
+          ]
+        }
+      ],
+      "MACHINE_READABLE_ZONE": [
+        {
+          "tl": [
+            0.04,
+            0.804
+          ],
+          "br": [
+            0.7795,
+            0.93
+          ]
+        }
+      ]
+    },
+    "back": {
+      "RELIGIOUS_NAME_OR_PSEUDONYM": [
+        {
+          "tl": [
+            0.0723,
+            0.225
+          ],
+          "br": [
+            0.783,
+            0.275
+          ]
+        }
+      ],
+      "AUTHORITY": [
+        {
+          "tl": [
+            0.0723,
+            0.4875
+          ],
+          "br": [
+            0.783,
+            0.5525
+          ]
+        }
+      ]
+    }
+  },
+  "i18n": {
+    "DOCUMENT_NAME": {
+      "en": "(Temporary) Identity Card",
+      "de": "Vorläufiger Personalausweis",
+      "fr": "Carte d'identité (temporaire)"
+    },
+    "SURNAME": {
+      "en": "Surname",
+      "de": "Name",
+      "fr": "Nom"
+    },
+    "GIVEN_NAME": {
+      "en": "Given names",
+      "de": "Vornamen",
+      "fr": "Prénoms"
+    },
+    "DATE_OF_BIRTH": {
+      "en": "Date of birth",
+      "de": "Geburtsdatum",
+      "fr": "Date de naissance"
+    },
+    "PLACE_OF_BIRTH": {
+      "en": "Place of birth",
+      "de": "Geburtsort",
+      "fr": "Lieu de naissance"
+    },
+    "NATIONALITY": {
+      "en": "Nationality",
+      "de": "Staatsangehörigkeit",
+      "fr": "Nationalité"
+    },
+    "HEIGHT": {
+      "en": "Height",
+      "de": "Größe",
+      "fr": "Taille"
+    },
+    "COLOUR_OF_EYES": {
+      "en": "Colour of eyes",
+      "de": "Augenfarbe",
+      "fr": "Couleur des yeux"
+    },
+    "ADDRESS": {
+      "en": "Address",
+      "de": "Gegenwärtige Anschrift",
+      "fr": "Adresse"
+    },
+    "DATE_OF_ISSUE": {
+      "en": "Date of issue",
+      "de": "Ausstellungsdatum",
+      "fr": "Date de délivrance"
+    },
+    "DATE_OF_EXPIRY": {
+      "en": "Date of expiry",
+      "de": "Gültig bis",
+      "fr": "Date d` expiration"
+    },
+    "SIGNATURE": {
+      "en": "Signature of bearer",
+      "de": "Unterschrift der Inhaberin/des Inhabers",
+      "fr": "signature de la titulaire/du titulaire"
+    },
+    "AUTHORITY": {
+      "en": "Authority",
+      "de": "Behörde",
+      "fr": "Autorité"
+    },
+    "RELIGIOUS_NAME_OR_PSEUDONYM": {
+      "en": "Religious name or pseudonym",
+      "de": "Ordens- oder Künstlername",
+      "fr": "Nom de religion ou pseudonyme"
+    }
+  }
+}

--- a/src/ausweiskopie/resources/schemas/document.json
+++ b/src/ausweiskopie/resources/schemas/document.json
@@ -67,6 +67,9 @@
             "diplomatic",
             "service",
             "children",
+            "noncitizen",
+            "refugee",
+            "stateless",
             "other"
           ],
           "type": "string",

--- a/src/ausweiskopie/resources/schemas/document.json
+++ b/src/ausweiskopie/resources/schemas/document.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "$id": "https://schema.varb.in/in.varb.Ausweiskopie/document.json",
+  "title": "Identity document description format",
   "type": "object",
   "required": [
     "id",
@@ -202,6 +203,9 @@
     "fieldset": {
       "type": "object",
       "properties": {
+        "DOCUMENT_NUMBER": {
+          "$ref": "#/$defs/field"
+        },
         "PHOTO": {
           "$ref": "#/$defs/field"
         },
@@ -221,6 +225,9 @@
           "$ref": "#/$defs/field"
         },
         "DATE": {
+          "$ref": "#/$defs/field"
+        },
+        "DATE_OF_ISSUE": {
           "$ref": "#/$defs/field"
         },
         "DATE_OF_EXPIRY": {

--- a/src/ausweiskopie/resources/schemas/draft-07.json
+++ b/src/ausweiskopie/resources/schemas/draft-07.json
@@ -1,0 +1,172 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-07/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "writeOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": true
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true,
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentEncoding": { "type": "string" },
+        "if": { "$ref": "#" },
+        "then": { "$ref": "#" },
+        "else": { "$ref": "#" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": true
+}

--- a/src/ausweiskopie/resources/translations.csv
+++ b/src/ausweiskopie/resources/translations.csv
@@ -73,3 +73,4 @@ EDITOR_MENU_CANCEL_DEFINE;Cancel selection;Auswahl abbrechen
 EDITOR_MENU_IMPORT_LAYOUT_FROM_CODE;Import Layout from FieldDefinition ...;Layout aus FieldDefinition importieren ...
 APP_NAME;Meine Ausweiskopie;Meine Ausweiskopie
 EDITOR;Field Editor - Meine Ausweiskopie;Feldeditor - Meine Ausweiskopie
+DOCUMENT_TYPE;Document type;Dokumententyp

--- a/src/ausweiskopie/ui/__init__.py
+++ b/src/ausweiskopie/ui/__init__.py
@@ -1,26 +1,21 @@
 """
 UI of the Ausweiskopie app.
 """
-import datetime
-import os
+import logging
 import sys
 import tkinter as tk
 import traceback
 import uuid
 from collections import OrderedDict
-from pydoc import classname
-from tkinter import filedialog
 from tkinter import messagebox
 from typing import Mapping
 
 from .dialogs import savefileasname
 from .threads import foreground, background
 from ..editor.window import EditorFrame
-from ..redact import Field, FIELDS_PASSPORT, FIELDS_NO_BACK, FIELDS_CH_NIDK_2023_FRONT, FIELDS_CH_NIDK_2023_BACK
-from ..redact import \
-    FIELDS_VORLAEUFIG_BACK, FIELDS_VORLAEUFIG_FRONT, \
-    FIELDS_NPA_FRONT_2021, FIELDS_NPA_FRONT_2010, FIELDS_NPA_FRONT_2019, \
-    FIELDS_NPA_BACK
+from ..redact import Field
+
+logger = logging.getLogger(__name__)
 
 try:
     import ttkbootstrap as ttk
@@ -249,11 +244,14 @@ class MainFrame(ttk.Frame):
         except IOError as e:
             messagebox.showerror("Error writing file",
                                  "File cannot be opened: %s" % e)
+            logger.error("Error writing file.", exc_info=e)
         except ValueError as e:
             messagebox.showerror("Unknown file extension",
                                  str(e))
-        except:
+            logger.error("User provided unknown file extension.", exc_info=e)
+        except Exception as e:
             messagebox.showerror("Unexpected error", traceback.format_exc())
+            logger.error("Unexpected error.", exc_info=e)
 
     def finish(self):
         ...

--- a/src/ausweiskopie/ui/__init__.py
+++ b/src/ausweiskopie/ui/__init__.py
@@ -6,6 +6,7 @@ import os
 import sys
 import tkinter as tk
 import traceback
+import uuid
 from collections import OrderedDict
 from pydoc import classname
 from tkinter import filedialog
@@ -31,7 +32,8 @@ except ImportError:
 from .elements import DocumentFrame, Selection, ColorButton, \
     MarkFrame
 from ..resources import \
-    ICON, EXAMPLE_NPA_2021, EXAMPLE_NPA_BACK, get_resource, _, ICON_COLORED
+    ICON, EXAMPLE_NPA_2021, EXAMPLE_NPA_BACK, get_resource, _, ICON_COLORED, \
+    document_title, Document, Side, load_documents
 
 from PIL import Image, ImageTk
 
@@ -50,47 +52,52 @@ def _get_version() -> str:
 
 class MainFrame(ttk.Frame):
     """Main application element."""
-    def __init__(self, root):
+    def __init__(self, root,  documents: dict[uuid.UUID, Document]):
         super(MainFrame, self).__init__(root)
 
         padding = {"padx": 8, "pady": 8}
 
+        # TODO: Refactor
+        # We need multiple data structures:
+        # An ordered list for the ui elements,
+        # and the dictionary that keeps them unique.
+        self.documents = documents
+        self.documents_sorted = sorted(documents.values(), key=document_title)
+
+        row = 0
+
         self.front = DocumentFrame(
             self, title=_("FRONT"),
-            document_types={
-                _("NPA_2021"):
-                    FIELDS_NPA_FRONT_2021,
-                _("NPA_2019"):
-                    FIELDS_NPA_FRONT_2019,
-                _("NPA_2010"):
-                    FIELDS_NPA_FRONT_2010,
-                _("VORLAEUFIG"):
-                    FIELDS_VORLAEUFIG_FRONT,
-                _("GERMAN_PASSPORT"):
-                    FIELDS_PASSPORT,
-                _("CH_NIDK_2023"):
-                    FIELDS_CH_NIDK_2023_FRONT,
-            },
             default=get_resource(EXAMPLE_NPA_2021),
-            document_type_changed_callback=self._on_doc_type_changed,
+            side=Side.FRONT,
+            document=self.documents_sorted[0],
         )
         self.back = DocumentFrame(
             self, title=_("BACK"),
-            document_types={
-                _("NPA_BACK"):
-                    FIELDS_NPA_BACK,
-                _("VORLAEUFIG_BACK"):
-                    FIELDS_VORLAEUFIG_BACK,
-                _("CH_NIDK_2023_BACK"):
-                    FIELDS_CH_NIDK_2023_BACK,
-                _("NO_BACK"):
-                    FIELDS_NO_BACK,
-            },
             default=get_resource(EXAMPLE_NPA_BACK),
-            document_type_changed_callback=self._on_doc_type_changed,
+            side=Side.BACK,
+            document=self.documents_sorted[0],
         )
-        self.front.grid(row=0, column=0, sticky="E", **padding)
-        self.back.grid(row=0, column=1, sticky="W", **padding)
+        self.front.grid(row=row, column=0, sticky="E", **padding)
+        self.back.grid(row=row, column=1, sticky="W", **padding)
+
+        row += 1
+
+        document_type = ttk.LabelFrame(self, text=_("DOCUMENT_TYPE"))
+        self.document_selection = ttk.Combobox(
+            document_type,
+        )
+        self.document_selection.configure(state="readonly")
+        # TODO: Do proper sorting
+        self.document_selection["values"] = tuple(
+            map(document_title, self.documents_sorted)
+        )
+        self.document_selection.current(0)
+        self.document_selection.bind("<<ComboboxSelected>>", self._on_doc_type_changed)
+        self.document_selection.pack(expand=1, fill="x", **padding)
+        document_type.grid(row=row, column=0, columnspan=2, sticky="WE", **padding)
+
+        row += 1
 
         fields_set = ttk.Labelframe(self, text=_("REDACT_FIELDS"))
         note = ttk.Label(fields_set, text=_("NOT_ALL_PRESENT"))
@@ -100,20 +107,27 @@ class MainFrame(ttk.Frame):
         for field in Field:
             fields[_(field)] = field
 
-        self.select_fields = Selection(fields_set, fields, {
-            Field.DOCUMENT_NUMBER, Field.CAN,
-            Field.NAME_AT_BIRTH, Field.AUTHORITY,
-            Field.HEIGHT, Field.COLOUR_OF_EYES,
-        }, columns=4)
-        self.select_fields.grid(row=1, column=0, sticky="WE", **padding)
+        self.select_fields = Selection(
+            fields_set, self.documents_sorted[0], 4
+        )
+#                                       fields, {
+#            Field.DOCUMENT_NUMBER, Field.CAN,
+#            Field.NAME_AT_BIRTH, Field.AUTHORITY,
+#            Field.HEIGHT, Field.COLOUR_OF_EYES,
+ #       }, columns=4)
+        self.select_fields.grid(row=row, column=0, sticky="WE", **padding)
 
         fields_set.grid_columnconfigure(0, weight=1)
         fields_set.grid_columnconfigure(1, weight=1)
-        fields_set.grid(row=1, column=0, columnspan=2, sticky="WE", **padding)
+        fields_set.grid(row=row, column=0, columnspan=2, sticky="WE", **padding)
+
+        row += 1
 
         self.watermark = MarkFrame(self, text=_("MARK_COPY"))
-        self.watermark.grid(row=2, column=0, columnspan=2, sticky="WE",
+        self.watermark.grid(row=row, column=0, columnspan=2, sticky="WE",
                             **padding)
+
+        row += 1
 
         small = ICON_IMAGE.copy()
         small.thumbnail((24, 24))
@@ -132,26 +146,33 @@ class MainFrame(ttk.Frame):
         create_button.grid(row=0, column=3, sticky="E")
         if STYLE:
             create_button.configure(bootstyle="success")
-        button_bar.grid(row=3, column=0, columnspan=2, sticky="WES")
+        button_bar.grid(row=row, column=0, columnspan=2, sticky="WES")
         button_bar.grid_columnconfigure(1, weight=1)
         self.grid_rowconfigure(3, weight=1)
 
         for i in range(2):
             self.grid_columnconfigure(i, weight=1)
 
-        self._on_doc_type_changed()
+        self._on_doc_type_changed(None)
 
-    def _on_doc_type_changed(self):
-        try:
-            front = self.front
-            back = self.back
-        except AttributeError:
-            return
+    def _on_doc_type_changed(self, _):
+        doc = self.documents_sorted[self.document_selection.current()]
+        self.select_fields.document = doc
+        self.front.document = doc
+        self.back.document = doc
 
-        print('Selected doc types: FRONT={}, BACK={}'.format(front.document_selection.get(), back.document_selection.get()))
-        all_fields_set = (set(front.document_types[front.document_selection.get()].keys())
-                          | set(back.document_types[back.document_selection.get()].keys()))
-        self.select_fields.set_visible_fields([_(str(x)) for x in all_fields_set])
+        #try:
+        #    front = self.front
+        #    back = self.back
+        #except AttributeError:
+        #    return
+
+        #front.document = self.documents_ordered[self._document_type.get()]
+
+        #print('Selected doc types: FRONT={}, BACK={}'.format(front.document_selection.get(), back.document_selection.get()))
+        #all_fields_set = (set(front.document_types[front.document_selection.get()].keys())
+        #                  | set(back.document_types[back.document_selection.get()].keys()))
+        #self.select_fields.set_visible_fields([_(str(x)) for x in all_fields_set])
 
 
     @property
@@ -248,6 +269,10 @@ def main():
     except ImportError:
         loop = None
 
+    # Load documents
+    # TODO: Do this interactively.
+    documents = load_documents(True)
+
     if hasattr(ttk, "Window"):
         root = ttk.Window()
     else:
@@ -263,7 +288,7 @@ def main():
             m = EditorFrame(root)
         else:
             root.wm_title(_('APP_NAME'))
-            m = MainFrame(root)
+            m = MainFrame(root, documents)
 
         m.pack(expand=1, fill="both")
 

--- a/src/ausweiskopie/ui/elements.py
+++ b/src/ausweiskopie/ui/elements.py
@@ -1,7 +1,9 @@
 """
 UI elements.
 """
+import io
 import tkinter
+import uuid
 from collections.abc import Callable
 from datetime import datetime
 import tkinter as tk
@@ -14,6 +16,7 @@ from PIL import ImageDraw
 
 from .dialogs import openfilename
 from .dnd import TkDND
+from ..resources import Document, Side, get_locale, Rectangle
 
 try:
     import ttkbootstrap as ttk
@@ -21,7 +24,7 @@ except ImportError:
     from tkinter import ttk
     ttk.Text = tk.Text
 
-from typing import Collection, Mapping, Optional
+from typing import Collection, Mapping, Optional, List
 
 from PIL import Image, ImageTk, UnidentifiedImageError
 
@@ -30,35 +33,23 @@ from ..redact import redact
 from ..redact.definitions import FieldDefinition, Field
 from ..resources import _
 
+
+padding = {"padx": 8, "pady": 8}
+
+
 class DocumentFrame(ttk.LabelFrame):
     """Element to select a document picture and its type."""
-    def __init__(self, root, title, default,
-                 document_types: Mapping[str, FieldDefinition],
-                 document_type_changed_callback: Optional[Callable] = None):
+    def __init__(self, root, title: str, default: io.BytesIO, side: Side, document: Document):
 
         super(DocumentFrame, self).__init__(root)
         self.configure(text=title)
-
-        self._document_type_changed_callback = document_type_changed_callback
+        self.side = side
 
         self.picture = Picture(self, default)
-        self.picture.pack(expand=1, fill="x", padx=8, pady=8)
+        self.picture.pack(expand=1, fill="x", **padding)
         self.picture.callback = self.change
 
-        self.document_types = document_types
-
-        self._document_type = tk.StringVar()
-        self._document_type.trace_add("write", self.change)
-
-        self.document_selection = ttk.Combobox(
-            self, textvariable=self._document_type
-        )
-        self.document_selection.configure(state="readonly")
-        self.document_selection["values"] = tuple(
-            sorted(document_types.keys())
-        )
-        self.document_selection.current(0)
-        self.document_selection.pack(expand=1, fill="x", padx=8, pady=8)
+        self._document = document
 
     def change(self, *args, **kwargs):
         """Callback to show field marks."""
@@ -71,17 +62,25 @@ class DocumentFrame(ttk.LabelFrame):
             "white",
             "black",
             [],
-            self.document_types[self._document_type.get()],
+            self.document.layout.get(self.side, {}),
             False,
             True
         )
-        if self._document_type_changed_callback:
-            self._document_type_changed_callback()
 
     @property
     def skip(self) -> bool:
         """Whether to skip this page."""
-        return not self.document_types[self._document_type.get()]
+        return bool(self._document.layout[self.side])
+
+    @property
+    def document(self) -> Document:
+        """The associated document of this frame."""
+        return self._document
+
+    @document.setter
+    def document(self, document: Document):
+        self._document = document
+        self.change()
 
     @staticmethod
     def redact_and_personalize(
@@ -89,8 +88,8 @@ class DocumentFrame(ttk.LabelFrame):
             text: str,
             text_color: str,
             redact_color: str,
-            redact_fields: Collection[Field],
-            document_type: FieldDefinition,
+            redact_fields: Collection[str],
+            document_type: Mapping[str, List[Rectangle]],
             grayscale: bool = True,
             mark: bool = False,
             text_transparency: float = 0.5,
@@ -142,7 +141,7 @@ class DocumentFrame(ttk.LabelFrame):
         new_image = DocumentFrame.redact_and_personalize(
             self.picture.image,
             text, text_color, redact_color, redact_fields,
-            self.document_types[self._document_type.get()],
+            self.document.layout.get(self.side, {}),
             grayscale,
             mark, text_transparency,
         )
@@ -239,41 +238,69 @@ class Picture(ttk.Frame):
 
 
 class Selection(ttk.Frame):
-    def __init__(self, master, kv: Mapping[str, str], defaults: set[str],
+    #_document: Document
+
+    def __init__(self, master, document: Document,
                  columns=1):
         super(Selection, self).__init__(master)
 
         self.buttons: dict[str, ttk.Checkbutton] = {}
         self.store: dict[str, tk.IntVar] = {}
 
+        self.columns = columns
         row, column = 0, 0
-
         self.grid_rowconfigure(row, weight=1)
-        for i in range(columns):
+        for i in range(self.columns):
             self.grid_columnconfigure(i, weight=1)
 
-        for display, value in kv.items():
+        self.document = document
+
+    @property
+    def document(self) -> Document:
+        return self._document
+
+    @document.setter
+    def document(self, document: Document):
+        self._document = document
+
+        fields = list(document.layout[Side.FRONT].keys())
+        fields.extend(document.layout.get(Side.BACK, {}).keys())
+
+        for _, button in self.buttons.items():
+            button.grid_forget()
+
+        self.buttons = {}
+        old = self.store
+        self.store = {}
+
+        row, column = 0, 0
+
+        for field in fields:
+            # TODO: Potentially load non-official translation from the global list
             variable = tk.IntVar()
-            if value in defaults:
-                variable.set(1)
+            if old.get(field):
+                variable.set(old.get(field).get())
+            a = document.i18n.get(field, {})
+            translation = a.get(get_locale(), a.get("en", field))
             btn = ttk.Checkbutton(
-                self, text=display, variable=variable, onvalue=1, offvalue=0,
-                state=DISABLED
+                self, text=translation, variable=variable, onvalue=1, offvalue=0,
             )
-            btn.grid(row=row, column=column, padx=8, pady=8, sticky="WE")
+            btn.grid(row=row, column=column, sticky="WE", **padding)
 
-            self.buttons[display] = btn
-            self.store[value] = variable
+            self.buttons[field] = btn
+            self.store[field] = variable
 
-            column = (column + 1) % columns
+            column = (column + 1) % self.columns
             if not column:
                 row += 1
                 self.grid_rowconfigure(row, weight=1)
 
+
     def set_visible_fields(self, enabled_fields: Collection[str]):
-        for key, btn in self.buttons.items():
-            is_enabled = key in enabled_fields
-            btn.configure(state=NORMAL if is_enabled else DISABLED)
+        #for key, btn in self.buttons.items():
+        #    is_enabled = key in enabled_fields
+        #    btn.configure(state=NORMAL if is_enabled else DISABLED)
+        ...
 
     def get_selections(self) -> Collection[str]:
         out = []
@@ -305,8 +332,6 @@ class MarkFrame(ttk.LabelFrame):
         self._percentage_value = 50
         self._percentage = tk.StringVar(value=str(self._percentage_value))
         self._percentage.trace_add("write", self._ensure_percentage)
-
-        padding = {"padx": 8, "pady": 8}
 
         # Column 0
         ttk.Checkbutton(self, text=_("GRAYSCALE"),

--- a/src/ausweiskopie/ui/elements.py
+++ b/src/ausweiskopie/ui/elements.py
@@ -70,7 +70,7 @@ class DocumentFrame(ttk.LabelFrame):
     @property
     def skip(self) -> bool:
         """Whether to skip this page."""
-        return bool(self._document.layout[self.side])
+        return not bool(self._document.layout[self.side])
 
     @property
     def document(self) -> Document:


### PR DESCRIPTION
The new scheme is described in #37. This WIP moves the definitions to [Pydantic](https://pypi.org/project/pydantic/); it already has half of the serialization / deserialization built in.

Full list of changes:
- [x] JSON schema:
  - Add document number and data of issue as "standard" fields
- Porting of ids to new JSON schema:
   - [x] German temporary ID
   - [ ] German "new" ids
   - [ ] German password
   - [ ] Swiss id
- [x] Dependencies:
  - Add Pydantic - on rare platforms (read: BSD) rust needs to be installed at compile time.
  - Fix the installation of the portals extra on Free-/OpenBSD (irrelevant to the PR, but a fix nonetheless)
  - Add tomli for reading/writing TOML documents (they may be better to read).
- [ ] Load JSON/TOML document types on startup
  - Note for implementation: Load them with importlib
- [ ] Change UI, as there is no separation between front and back with the new schema any more